### PR TITLE
bug fix: more stable navigation on first import

### DIFF
--- a/Assets/AnimatableVolumeComponent/Editor/AnimatableVolumeComponentEditorSettings.cs
+++ b/Assets/AnimatableVolumeComponent/Editor/AnimatableVolumeComponentEditorSettings.cs
@@ -27,8 +27,16 @@ namespace TsukimiNeko.AnimatableVolumeComponent.Internal
         private const string Cancel_jp = "後で作成";
 
         [InitializeOnLoadMethod]
+        private static void Initialize()
+        {
+            // sometimes it may cause error when doing something on importing, so wait 1 frame
+            EditorApplication.update += NavigateOnFirstImport;
+        }
+
         private static void NavigateOnFirstImport()
         {
+            EditorApplication.update -= NavigateOnFirstImport;
+
             var settings = GetOrCreateSettings();
             if (!settings) return;
 
@@ -70,7 +78,7 @@ namespace TsukimiNeko.AnimatableVolumeComponent.Internal
 
             var instance = CreateInstance<AnimatableVolumeComponentEditorSettings>();
             AssetDatabase.CreateAsset(instance, soPath);
-            AssetDatabase.SaveAssetIfDirty(instance);
+            instance = AssetDatabase.LoadAssetAtPath<AnimatableVolumeComponentEditorSettings>(soPath);
             return instance;
         }
     }


### PR DESCRIPTION
- the first-import-navigation sometimes conducts errors, and doesn't have stable behaviour
  - error `Unable to import newly created asset`
  - `isFirstImport` not set to false after navigation dialog
- → wait 1 frame after imported/InitializeOnLoad